### PR TITLE
Fix legacy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # legacy.reactjs.org
 
-This repo contains the source code and documentation powering [legacy.reactjs.org](https://reactjs.org/).
+This repo contains the source code and documentation powering [legacy.reactjs.org](https://legacy.reactjs.org/).
 
 ## Not actively maintained
 


### PR DESCRIPTION
The `legacy` subdomain was missing from the old URL, the way it is it redirects to the new website.
