### PR TITLE
Fix alternate lang tags

### DIFF
--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -57,13 +57,24 @@ const TitleAndMetaTags = ({
       <meta property="og:title" content={title} />
       <meta property="og:type" content={ogType} />
       {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
-      <meta property="og:image" content="https://legacy.reactjs.org/logo-og.png" />
+      <meta
+        property="og:image"
+        content="https://legacy.reactjs.org/logo-og.png"
+      />
       <meta
         property="og:description"
         content={ogDescription || defaultDescription}
       />
       <meta property="fb:app_id" content="623268441017527" />
-      {canonicalUrl && <link rel="canonical" href={canonicalUrl.replace('https://reactjs.org', 'https://legacy.reactjs.org')} />}
+      {canonicalUrl && (
+        <link
+          rel="canonical"
+          href={canonicalUrl.replace(
+            'https://reactjs.org',
+            'https://legacy.reactjs.org',
+          )}
+        />
+      )}
       {canonicalUrl && (
         <link
           rel="alternate"

--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -35,7 +35,7 @@ const alternatePages = canonicalUrl => {
       href={canonicalUrl.replace(
         urlRoot,
         `https://${
-          language.code === 'en' ? 'legacy.' : `${language.code}.`
+          language.code === 'en' ? '' : `${language.code}.`
         }reactjs.org`,
       )}
     />
@@ -66,15 +66,7 @@ const TitleAndMetaTags = ({
         content={ogDescription || defaultDescription}
       />
       <meta property="fb:app_id" content="623268441017527" />
-      {canonicalUrl && (
-        <link
-          rel="canonical"
-          href={canonicalUrl.replace(
-            'https://reactjs.org',
-            'https://legacy.reactjs.org',
-          )}
-        />
-      )}
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
       {canonicalUrl && (
         <link
           rel="alternate"

--- a/src/components/TitleAndMetaTags/TitleAndMetaTags.js
+++ b/src/components/TitleAndMetaTags/TitleAndMetaTags.js
@@ -35,7 +35,7 @@ const alternatePages = canonicalUrl => {
       href={canonicalUrl.replace(
         urlRoot,
         `https://${
-          language.code === 'en' ? '' : `${language.code}.`
+          language.code === 'en' ? 'legacy.' : `${language.code}.`
         }reactjs.org`,
       )}
     />
@@ -43,7 +43,7 @@ const alternatePages = canonicalUrl => {
 };
 
 const defaultPage = canonicalUrl => {
-  return canonicalUrl.replace(urlRoot, 'https://reactjs.org');
+  return canonicalUrl.replace(urlRoot, 'https://legacy.reactjs.org');
 };
 
 const TitleAndMetaTags = ({
@@ -57,13 +57,13 @@ const TitleAndMetaTags = ({
       <meta property="og:title" content={title} />
       <meta property="og:type" content={ogType} />
       {canonicalUrl && <meta property="og:url" content={canonicalUrl} />}
-      <meta property="og:image" content="https://reactjs.org/logo-og.png" />
+      <meta property="og:image" content="https://legacy.reactjs.org/logo-og.png" />
       <meta
         property="og:description"
         content={ogDescription || defaultDescription}
       />
       <meta property="fb:app_id" content="623268441017527" />
-      {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+      {canonicalUrl && <link rel="canonical" href={canonicalUrl.replace('https://reactjs.org', 'https://legacy.reactjs.org')} />}
       {canonicalUrl && (
         <link
           rel="alternate"

--- a/src/site-constants.js
+++ b/src/site-constants.js
@@ -7,7 +7,7 @@
 
 // NOTE: We can't just use `location.toString()` because when we are rendering
 // the SSR part in node.js we won't have a proper location.
-const urlRoot = 'https://reactjs.org';
+const urlRoot = 'https://legacy.reactjs.org';
 const version = '18.2.0';
 const babelURL = 'https://unpkg.com/babel-standalone@6.26.0/babel.min.js';
 


### PR DESCRIPTION
## Overview

The search index for the legacy site (in english) is kinda borked. For many pages, neither the `legacy.reactjs.org/{slug}` site is indexed, nor the `reactjs.org/{slug}` site. When this happens, Google is returning results for the first translated site with matches, and since many of the translated sites still have english content, a partially translated doc is indexed.

<img width="1219" alt="Screenshot 2023-04-14 at 3 23 04 PM" src="https://user-images.githubusercontent.com/2440089/232137414-31323c80-92f2-4724-8ede-d6a270659fce.png">


## Why is this happening

According to the Google search console, when this happens it's because:

- `reactjs.org`: Page is not indexed, redirects to `legacy.reactjs.org` 🛑
- `legacy.reactjs.org`: Page is not indexed, alternate page with proper canonical tag `{lang.reactjs.org}` 🛑

## Why doesn't this happen on all pages?

If you look deeper, you'll see that this doesn't happen on e.g. the Getting Started page:

<img width="1244" alt="Screenshot 2023-04-14 at 3 23 44 PM" src="https://user-images.githubusercontent.com/2440089/232137529-74676e3f-ca67-4270-a1d7-53954facee97.png">

Looking at the Google Search index, you see:

- `reactjs.org`:  Page is not indexed, redirects to `legacy.reactjs.org` 🛑
- `legacy.reactjs.org`: Page is indexed ✅

I believe this is happening because _all_ of the translated sites are fully translated to their corresponding language. So google doesn't trigger the "Alternate page with proper canonical tag" rule for those pages.

# Fix

I've added `legacy` to all `https://reactjs.org` link, but we'll also need to update _all_ of the translated docs repos to make the same change. Additionally, if we migrate the `https://{lang}.reactjs.org` sites to `https://{lang}.legacy.reactjs.org` we'll need to update every repo.

## Before

```html
<link rel="canonical" href="https://reactjs.org/"/>
<link rel="alternate" href="https://reactjs.org/" hreflang="x-default"/>
<link rel="alternate" hreflang="en" href="https://reactjs.org/"/>
<link rel="alternate" hreflang="ar" href="https://ar.reactjs.org/"/>
<link rel="alternate" hreflang="az" href="https://az.reactjs.org/"/>
<link rel="alternate" hreflang="es" href="https://es.reactjs.org/"/>
<link rel="alternate" hreflang="fr" href="https://fr.reactjs.org/"/>
<link rel="alternate" hreflang="hu" href="https://hu.reactjs.org/"/>
<link rel="alternate" hreflang="it" href="https://it.reactjs.org/"/>
<link rel="alternate" hreflang="ja" href="https://ja.reactjs.org/"/>
<link rel="alternate" hreflang="ko" href="https://ko.reactjs.org/"/>
<link rel="alternate" hreflang="mn" href="https://mn.reactjs.org/"/>
<link rel="alternate" hreflang="pl" href="https://pl.reactjs.org/"/>
<link rel="alternate" hreflang="pt-br" href="https://pt-br.reactjs.org/"/>
<link rel="alternate" hreflang="ru" href="https://ru.reactjs.org/"/>
<link rel="alternate" hreflang="tr" href="https://tr.reactjs.org/"/>
<link rel="alternate" hreflang="uk" href="https://uk.reactjs.org/"/>
<link rel="alternate" hreflang="zh-hans" href="https://zh-hans.reactjs.org/"/>
<link rel="alternate" hreflang="zh-hant" href="https://zh-hant.reactjs.org/"/>
```

## After

```html
<link rel="canonical" href="https://legacy.reactjs.org/">
<link rel="alternate" href="https://legacy.reactjs.org/" hreflang="x-default">
<link rel="alternate" hreflang="en" href="https://legacy.reactjs.org/">
<link rel="alternate" hreflang="ar" href="https://ar.reactjs.org/">
<link rel="alternate" hreflang="az" href="https://az.reactjs.org/">
<link rel="alternate" hreflang="es" href="https://es.reactjs.org/">
<link rel="alternate" hreflang="fr" href="https://fr.reactjs.org/">
<link rel="alternate" hreflang="hu" href="https://hu.reactjs.org/">
<link rel="alternate" hreflang="it" href="https://it.reactjs.org/">
<link rel="alternate" hreflang="ja" href="https://ja.reactjs.org/">
<link rel="alternate" hreflang="ko" href="https://ko.reactjs.org/">
<link rel="alternate" hreflang="mn" href="https://mn.reactjs.org/">
<link rel="alternate" hreflang="pl" href="https://pl.reactjs.org/">
<link rel="alternate" hreflang="pt-br" href="https://pt-br.reactjs.org/">
<link rel="alternate" hreflang="ru" href="https://ru.reactjs.org/">
<link rel="alternate" hreflang="tr" href="https://tr.reactjs.org/">
<link rel="alternate" hreflang="uk" href="https://uk.reactjs.org/">
<link rel="alternate" hreflang="zh-hans" href="https://zh-hans.reactjs.org/">
<link rel="alternate" hreflang="zh-hant" href="https://zh-hant.reactjs.org/">
```