### PR TITLE
Modified single-file-example.html raw file link

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -47,7 +47,7 @@ React has been designed from the start for gradual adoption, and **you can use a
 
 If you're interested in playing around with React, you can use an online code playground. Try a Hello World template on [CodePen](codepen://hello-world), [CodeSandbox](https://codesandbox.io/s/new), or [Stackblitz](https://stackblitz.com/fork/react).
 
-If you prefer to use your own text editor, you can also [download this HTML file](https://raw.githubusercontent.com/reactjs/reactjs.org/main/static/html/single-file-example.html), edit it, and open it from the local filesystem in your browser. It does a slow runtime code transformation, so we'd only recommend using this for simple demos.
+If you prefer to use your own text editor, you can also [download this HTML file](https://raw.githubusercontent.com/reactjs/legacy.reactjs.org/main/static/html/single-file-example.html), edit it, and open it from the local filesystem in your browser. It does a slow runtime code transformation, so we'd only recommend using this for simple demos.
 
 ### Add React to a Website {#add-react-to-a-website}
 


### PR DESCRIPTION
Modified the documentation of [legacy.reactjs.org/content/docs/getting-started.md](https://github.com/reactjs/legacy.reactjs.org/blob/main/content/docs/getting-started.md)

In the [Online Playgrounds](https://legacy.reactjs.org/docs/getting-started.html#online-playgrounds) section, the Provided link for the [download this HTML file](https://raw.githubusercontent.com/reactjs/reactjs.org/main/static/html/single-file-example.html) is not working because of renaming of the repository from `reactjs.org` to `legacy.reactjs.org`

So to address the above issue I'm making a pull request by modifying the link from [https://raw.githubusercontent.com/reactjs/reactjs.org/main/static/html/single-file-example.html](https://raw.githubusercontent.com/reactjs/reactjs.org/main/static/html/single-file-example.html) to [https://raw.githubusercontent.com/reactjs/legacy.reactjs.org/main/static/html/single-file-example.html](https://raw.githubusercontent.com/reactjs/reactjs.org/main/static/html/single-file-example.html)

Thank you 🤝
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/legacy.reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
