### PR TITLE
Add error decoder redirects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -387,7 +387,7 @@
         {
           "type": "query",
           "key": "invariant",
-          "value": "(?<code>)"
+          "value": "(<code>)"
         }
       ],
       "destination": "https://react.dev/errors/:code",

--- a/vercel.json
+++ b/vercel.json
@@ -387,10 +387,10 @@
         {
           "type": "query",
           "key": "invariant",
-          "value": "137"
+          "value": "<code>"
         }
       ],
-      "destination": "https://react.dev/errors/137",
+      "destination": "https://react.dev/errors/:code",
       "permanent": true
     },
     {

--- a/vercel.json
+++ b/vercel.json
@@ -387,7 +387,7 @@
         {
           "type": "query",
           "key": "invariant",
-          "value": "(<code>)"
+          "value": "(?<code>.*)"
         }
       ],
       "destination": "https://react.dev/errors/:code",

--- a/vercel.json
+++ b/vercel.json
@@ -382,6 +382,18 @@
       "permanent": false
     },
     {
+      "source": "/docs/error-decoder.html",
+      "has": [
+        {
+          "type": "query",
+          "key": "invariant",
+          "value": "137"
+        }
+      ],
+      "destination": "https://react.dev/errors/137",
+      "permanent": true
+    },
+    {
       "source": "/version/15.6",
       "destination": "https://react-legacy.netlify.app",
       "permanent": false

--- a/vercel.json
+++ b/vercel.json
@@ -387,7 +387,7 @@
         {
           "type": "query",
           "key": "invariant",
-          "value": "<code>"
+          "value": "(?<code>)"
         }
       ],
       "destination": "https://react.dev/errors/:code",


### PR DESCRIPTION
Adds redirects for error decoder on react.dev:


Preview:

- Error code only: https://legacy-reactjs-ddkzh8wyb-fbopensource.vercel.app/docs/error-decoder.html/?invariant=421
- Error code and single argument: https://legacy-reactjs-ddkzh8wyb-fbopensource.vercel.app/docs/error-decoder.html/?invariant=137&args[]=%3Cbr%20/%3E
- Error code and multiple arguments: https://legacy-reactjs-ddkzh8wyb-fbopensource.vercel.app/docs/error-decoder.html/?invariant=377&args[0]=114514n&args[1]=count
- Error code and missing the only argument: https://legacy-reactjs-ddkzh8wyb-fbopensource.vercel.app/docs/error-decoder.html/?invariant=137
- Error code and missing some arguments:https://legacy-reactjs-ddkzh8wyb-fbopensource.vercel.app/docs/error-decoder.html/?invariant=377&args[0]=&args[1]=count